### PR TITLE
 CIS-8469 - Team planner, IE 10: Unable to get property 'initialIndex…

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-addons-css-transition-group": "^15.1.0",
     "react-click-outside": "^2.1.0",
     "react-dom": "^15.1.0",
-    "react-list": "^0.7.20",
+    "react-list": "^0.8.0",
     "react-overlays": "^0.6.3",
     "react-prop-types": "^0.2.1",
     "react-redux": "^4.4.1",


### PR DESCRIPTION
…' on 'Find Employee' clicking